### PR TITLE
normalize domain names

### DIFF
--- a/CP3/CP3_eval_script.py
+++ b/CP3/CP3_eval_script.py
@@ -7,11 +7,16 @@ import json
 # how to use: python CP3_eval_script.py ground_truth_sample_CP3.json submission_sample_CP3.json output_sample_CP3.txt
 output_file = open(sys.argv[3], "w")
 
+
+def get_domain(url):
+    return tldextract.extract(url).registered_domain.lower()
+
+
 ################################################
 # ground truth data
 gt_outputs = open(sys.argv[1], "r")
 gt_sites = [line.rstrip('\n') for line in gt_outputs]
-gt_domains = set([tldextract.extract(url).registered_domain for url in gt_sites])
+gt_domains = set([get_domain(url) for url in gt_sites])
 gt_urls = set([url.split("://")[-1] for url in gt_sites])
 ################################################
 
@@ -20,7 +25,7 @@ gt_urls = set([url.split("://")[-1] for url in gt_sites])
 sub_outputs = open(sys.argv[2], "r")
 sub_docs = [json.loads(line) for line in sub_outputs]
 sub_sites =[doc['url'] for doc in sub_docs]
-sub_domains = set([tldextract.extract(url).registered_domain for url in sub_sites])
+sub_domains = set([get_domain(url) for url in sub_sites])
 sub_urls = set([url.split("://")[-1] for url in sub_sites])
 ################################################
 


### PR DESCRIPTION
Domain names are case insensitive, but `tldextract.extract(url).registered_domain` preserves their case.

Without this change domains are be considered different if they only differ in case.