### PR TITLE
normalize URLs; add a progress bar

### DIFF
--- a/CP3/CP3_eval_script.py
+++ b/CP3/CP3_eval_script.py
@@ -1,31 +1,57 @@
 #!/usr/bin/env python
 from __future__ import print_function
+import re
 import sys
+
 import tldextract
-import json
+from six.moves.urllib.parse import urlparse
+try:
+    from tqdm import tqdm
+except ImportError:
+    tqdm = lambda it, *args: it
+# it requires w3lib >= 1.15.0
+from w3lib.url import canonicalize_url
+
 
 # how to use: python CP3_eval_script.py ground_truth_sample_CP3.json submission_sample_CP3.json output_sample_CP3.txt
 output_file = open(sys.argv[3], "w")
+
+
+# XXX: copied from Scrapy
+def add_http_if_no_scheme(url):
+    """Add http as the default scheme if it is missing from the url."""
+    match = re.match(r"^\w+://", url, flags=re.I)
+    if not match:
+        parts = urlparse(url)
+        scheme = "http:" if parts.netloc else "http://"
+        url = scheme + url
+
+    return url
 
 
 def get_domain(url):
     return tldextract.extract(url).registered_domain.lower()
 
 
+def normalize_url(url):
+    url = add_http_if_no_scheme(url)
+    return canonicalize_url(url).replace('https://', 'http://', 1)
+
+
 ################################################
 # ground truth data
 gt_outputs = open(sys.argv[1], "r")
 gt_sites = [line.rstrip('\n') for line in gt_outputs]
-gt_domains = set([get_domain(url) for url in gt_sites])
-gt_urls = set([url.split("://")[-1] for url in gt_sites])
+gt_domains = {get_domain(url) for url in gt_sites}
+gt_urls = {normalize_url(url) for url in gt_sites}
 ################################################
 
 ################################################
 # submission data
 sub_outputs = open(sys.argv[2], "r")
-sub_sites = [line.rstrip('\n') for line in sub_outputs]
-sub_domains = set([get_domain(url) for url in sub_sites])
-sub_urls = set([url.split("://")[-1] for url in sub_sites])
+sub_sites = [line.rstrip('\n') for line in tqdm(sub_outputs, "reading submission")]
+sub_domains = {get_domain(url) for url in tqdm(sub_sites, "extracting domains")}
+sub_urls = {normalize_url(url) for url in tqdm(sub_sites, "normalizing urls")}
 ################################################
 
 


### PR DESCRIPTION
In ground truth URLs there are URLs with GET arguments. The order of arguments doesn't matter almost always; and often it is arbitrary on websites. This is an issue when comparing URLs: `http://example.com?foo=bar&egg=spam` is not the same as `http://example.com?egg=spam&foo=bar` when they are compared as strings. There is a few other similar issues:
- if URL domains has different case then URLs won't match (it was fixed for domain comparison, but not for URLs);
- `http://example.com` should be the same as `http://example.com/?` which is not the case;
- percent-encoded data is case insensitive, so `%2f` should be the same as `%2F`
- etc.

In this PR that's fixed by using [w3lib.url.canonicalize_url](http://w3lib.readthedocs.io/en/latest/w3lib.html#w3lib.url.canonicalize_url) function; one needs the most recent w3lib (v1.15.0) to use it. For us this normalization make comparison results different for ~2% URLs.

This PR also adds progress indication; to use it `pip install tqdm`.
